### PR TITLE
Community name issue fixed

### DIFF
--- a/src/components/ui/textfields/TextFieldFull.vue
+++ b/src/components/ui/textfields/TextFieldFull.vue
@@ -2,7 +2,7 @@
   <div class="textFieldFull">
     <h2 class="textFieldFull__title">{{ title }}</h2>
     <div class="textFieldFull__input">
-      <input class="textFieldFull__input--field" :maxlength="maxLength" />
+      <input class="textFieldFull__input--field" :maxlength="maxLength" @input="handleInput" :value="modelValue" />
     </div>
     <p class="textFieldFull__description">
       {{ description }}
@@ -18,7 +18,20 @@ export default defineComponent({
     title: { type: String, required: true },
     description: { type: String, required: true },
     maxLength: Number,
+    modelValue: { type:String, required: true },
   },
+  data() {
+    console.log('hello', this.modelValue);
+    return {
+      content: this.modelValue,
+    }
+  },
+  methods: {
+    handleInput(e: any) {
+      console.log(`changed: ${e.target.value}`);
+      this.$emit('update:modelValue', e.target.value);
+    }
+  }
 });
 </script>
 

--- a/src/views/community-view/main-view/MainView.vue
+++ b/src/views/community-view/main-view/MainView.vue
@@ -30,7 +30,7 @@ export default {
   },
   computed: {
     getCurrentView() {
-      return this.$store.getters.getCurrentCommunityView;
+      return this.$store.getters.getCurrentCommunityView ?? this.$store.getters.getCommunities[0];
     },
   },
 };

--- a/src/views/community-view/main-view/channel-view/ChannelView.vue
+++ b/src/views/community-view/main-view/channel-view/ChannelView.vue
@@ -2,7 +2,7 @@
   <div class="channelView">
     <div class="channelView__messages" ref="messagesContainer">
       <direct-message
-        v-for="message in getCurrentChannel.currentExpressionMessages"
+        v-for="message in getCurrentChannel?.currentExpressionMessages"
         :key="message.url"
         :message="JSON.parse(message.data)"
       ></direct-message>
@@ -166,12 +166,13 @@ export default defineComponent({
   flex-direction: column;
   justify-content: space-between;
   position: relative;
-  max-height: 100vh;
+  min-height: 100vh;
 
   &__messages {
     overflow: scroll;
     // 9.5 = 7.5rem (height of MainVewTopBar) + 2rem
     padding: 9.5rem 2rem 7.5rem 2rem;
+    flex: 1;
   }
 }
 </style>


### PR DESCRIPTION
@jdeepee This fixes the issue where we were getting an empty string. I also noticed that even when I was able to pass a valid name the query returns a new community with the empty name it still creates a default channel with a community name. 