### PR TITLE
Fix background notification

### DIFF
--- a/src/utils/showMessageNotification.ts
+++ b/src/utils/showMessageNotification.ts
@@ -35,7 +35,7 @@ export default async (
 
   // Only show the notification when the the message is not from self & the active community & channel is different
   if (
-    isMinimized ||
+    (isMinimized && !channel?.notifications.mute) ||
     (store.state.userDid !== authorDid &&
       (community?.perspective === communityId
         ? channel?.perspective !== channelId


### PR DESCRIPTION
This PR fixes an issue where if the application was in the foreground or background notification would trigger even if the channel was muted.