### PR TITLE
No language when app restarts

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -230,6 +230,10 @@ export default defineComponent({
 
     window.api.send("getLangPath");
 
+    window.api.receive("unlockedStateOff", () => {
+      this.$store.commit("updateAgentLockState", false);
+    });
+
     window.api.receive("getLangPathResponse", (data: string) => {
       // console.log(`Received language path from main thread: ${data}`);
       this.$store.commit("setLanguagesPath", data);

--- a/src/background.ts
+++ b/src/background.ts
@@ -353,6 +353,8 @@ app.on("will-quit", async () => {
 
 app.on("before-quit", async () => {
   isQuiting = true;
+
+  win.webContents.send("unlockedStateOff");
 });
 
 app.on("activate", () => {

--- a/src/preload.js
+++ b/src/preload.js
@@ -31,6 +31,7 @@ contextBridge.exposeInMainWorld("api", {
       "download_progress",
       "globalError",
       "windowState",
+      "unlockedStateOff"
     ];
     if (validChannels.includes(channel)) {
       // Deliberately strip event as it includes `sender`

--- a/src/store/actions/loadExpressionLanguages.ts
+++ b/src/store/actions/loadExpressionLanguages.ts
@@ -15,16 +15,19 @@ export interface Payload {
 export default async ({ commit, getters }: Context): Promise<void> => {
   try {
     const languages = await getLanguages();
-    for (const language of languages) {
-      if (language.iconFor) {
-        if (!getters.getLanguageUI(language.address!)) {
-          const uiData: ExpressionUIIcons = {
-            languageAddress: language!.address!,
-            createIcon: language!.constructorIcon!.code!,
-            viewIcon: language!.iconFor!.code!,
-            name: language!.name!,
-          };
-          commit("addExpressionUI", uiData);
+    
+    if (languages) {
+      for (const language of languages) {
+        if (language.iconFor) {
+          if (!getters.getLanguageUI(language.address!)) {
+            const uiData: ExpressionUIIcons = {
+              languageAddress: language!.address!,
+              createIcon: language!.constructorIcon!.code!,
+              viewIcon: language!.iconFor!.code!,
+              name: language!.name!,
+            };
+            commit("addExpressionUI", uiData);
+          }
         }
       }
     }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -163,6 +163,20 @@ export interface AddChannel {
 
 const vuexLocal = new VuexPersistence<State>({
   storage: window.localStorage,
+  reducer: state => ({
+    communities: state.communities,
+    localLanguagesPath: state.localLanguagesPath,
+    databasePerspective: state.databasePerspective,
+    expressionUI: state.expressionUI,
+    userProfile: state.userProfile,
+    userDid: state.userDid,
+    agentInit: state.agentInit,
+    agentUnlocked: state.agentUnlocked,
+    ui: {
+      showSidebar: state.ui.showSidebar,
+      theme: state.ui.theme,
+    }
+  })
 });
 
 export default createStore({


### PR DESCRIPTION
When we close the app the `agentUnlocked` state doesn't go back to `false`, so on the next start the app starts with `agentUnlocked` being true which then triggers load languages which throws this error `"object null is not iterable (cannot read property Symbol(Symbol.iterator))"`.

Ideally, we would want to keep this state from being stored locally but it causes us to log out on each hot restart on the development env, that's why I have kept it in the store still. 

Any other suggestions on handling this?