### PR TITLE
Mention did key fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "main": "background.js",
   "dependencies": {
     "@apollo/client": "3.3.20",
-    "@junto-foundation/junto-elements": "^0.3.5",
+    "@junto-foundation/junto-elements": "^0.3.7",
     "@perspect3vism/ad4m": "0.1.7",
     "@perspect3vism/ad4m-executor": "^0.1.4",
     "@tiptap/vue-3": "^2.0.0-beta.45",

--- a/src/components/message-item/MessageItem.vue
+++ b/src/components/message-item/MessageItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="message-item">
+  <div class="message-item" ref="messageItem">
     <div class="message-item__left-column">
       <j-avatar
         class="message-item__avatar"
@@ -71,8 +71,8 @@ export default defineComponent({
     openedProfile: Object,
   },
   mounted() {
-    const mentionElements = document.querySelectorAll(".mention");
-    const emojiElements = document.querySelectorAll(".emoji");
+    const mentionElements = (this.$refs.messageItem as any).querySelectorAll(".mention");
+    const emojiElements = (this.$refs.messageItem as any).querySelectorAll(".emoji");
 
     for (const ele of emojiElements) {
       const emoji = ele as HTMLElement;

--- a/src/views/channel-view/ChannelFooter.vue
+++ b/src/views/channel-view/ChannelFooter.vue
@@ -52,7 +52,7 @@ export default defineComponent({
           ({
             name: m.data.profile["foaf:AccountName"],
             //todo: this should not be replaced, we want the full did identifier in the mentions in case message is consumed by another application
-            id: m.author.replace("did:key:", ""),
+            id: m.author,
             trigger: "@",
           } as MentionTrigger)
       );

--- a/src/views/channel-view/ChannelView.vue
+++ b/src/views/channel-view/ChannelView.vue
@@ -177,8 +177,7 @@ export default defineComponent({
       }
       if (label?.startsWith("@")) {
         this.showProfile = true;
-        //todo: this should not be here, the mention should have the did already formatted correctly
-        this.activeProfile = "did:key:" + id;
+        this.activeProfile = id;
       }
     },
     markAsRead() {


### PR DESCRIPTION
This PR fixes the issue where we were removing the `:key:` so that it doesn't get parsed as 🔑. This PR relies on [#7](https://github.com/juntofoundation/junto-elements/pull/7) in junto-elements.