### PR TITLE
WIP: Removing of polling for community metadata

### DIFF
--- a/src/core/methods/createChannel.ts
+++ b/src/core/methods/createChannel.ts
@@ -6,7 +6,7 @@ import {
   JuntoExpressionReference,
 } from "@/store/types";
 import { v4 } from "uuid";
-import { Perspective, Link } from "@perspect3vism/ad4m";
+import { Perspective } from "@perspect3vism/ad4m";
 import type { PerspectiveHandle } from "@perspect3vism/ad4m";
 import { addPerspective } from "../mutations/addPerspective";
 import { templateLanguage } from "../mutations/templateLanguage";
@@ -58,21 +58,8 @@ export async function createChannel({
     socialContextLanguage.address,
     meta
   );
-  console.debug("Create a neighbourhood with result", neighbourhood);
-
-  const channelLink = new Link({
-    source: `${sourcePerspective.sharedUrl}://self`,
-    target: neighbourhood,
-    predicate: "sioc://has_space",
-  });
-  const addLinkToChannel = await createLink(
-    sourcePerspective.uuid,
-    channelLink
-  );
-  console.debug(
-    "Created new link on source social-context with result",
-    addLinkToChannel
-  );
+  console.log("Create a neighbourhood with result", neighbourhood);
+  perspective.sharedUrl = neighbourhood;
 
   //Add link on channel social context declaring type
   const addChannelTypeLink = await createLink(perspective.uuid, {

--- a/src/store/data/actions/createChannel.ts
+++ b/src/store/data/actions/createChannel.ts
@@ -3,6 +3,8 @@ import { useAppStore } from "@/store/app";
 import { ChannelState, MembraneType } from "@/store/types";
 import { useDataStore } from "..";
 import { useUserStore } from "@/store/user";
+import { Link } from "@perspect3vism/ad4m";
+import { createLink } from "@/core/mutations/createLink";
 
 export interface Payload {
   communityId: string;
@@ -30,6 +32,13 @@ export default async (payload: Payload): Promise<ChannelState> => {
         communityId: community.neighbourhood.perspective.uuid,
         channel,
       });
+
+      const channelLink = new Link({
+        source: community.neighbourhood.perspective.sharedUrl!,
+        target: channel.neighbourhood.perspective.sharedUrl!,
+        predicate: "sioc://has_space",
+      });
+      await createLink(community.neighbourhood.perspective.uuid, channelLink);
 
       return channel;
     } else {

--- a/src/store/data/actions/getNeighbourhoodChannels.ts
+++ b/src/store/data/actions/getNeighbourhoodChannels.ts
@@ -1,89 +1,53 @@
-import { print } from "graphql/language/printer";
 import { joinChannelFromSharedLink } from "@/core/methods/joinChannelFromSharedLink";
-import { PERSPECTIVE_LINK_QUERY } from "@/core/graphql_queries";
 import { LinkQuery } from "@perspect3vism/ad4m";
 import { useDataStore } from "..";
+import { getLinks } from "@/core/queries/getLinks";
 
 export interface Payload {
   communityId: string;
 }
 
-const channelLinksWorker = new Worker("pollingWorker.js");
-let isCallbackRunning = false;
-
 /// Function that uses web workers to poll for channels and new group expressions on a community
-export default async ({ communityId }: Payload): Promise<Worker> => {
+export default async ({ communityId }: Payload): Promise<void> => {
   const dataStore = useDataStore();
 
   try {
-    //NOTE/TODO: if this becomes too heavy for certain communities this might be best executed via a refresh button
     const community = dataStore.getCommunity(communityId);
 
-    //Start the worker looking for channels
-    channelLinksWorker.postMessage({
-      interval: 10000,
-      staticSleep: true,
-      query: print(PERSPECTIVE_LINK_QUERY),
-      variables: {
-        uuid: community.neighbourhood.perspective.uuid,
-        query: new LinkQuery({
-          source: `${community.neighbourhood.neighbourhoodUrl}://self`,
-          predicate: "sioc://has_space",
-        }),
-      },
-      name: `Channel links for ${community.neighbourhood.name}`,
-      dataKey: "perspectiveQueryLinks",
-    });
+    const channelLinks = await getLinks(
+      community.neighbourhood.perspective.uuid,
+      new LinkQuery({
+        source: `${community.neighbourhood.neighbourhoodUrl}://self`,
+        predicate: "sioc://has_space",
+      })
+    );
 
-    channelLinksWorker.onerror = function (e) {
-      throw new Error(e.toString());
-    };
-
-    channelLinksWorker.addEventListener("message", async (e) => {
-      if (!isCallbackRunning) {
-        isCallbackRunning = true;
-        //Check that no other worker callback is executing
-        try {
-          const channelLinks = e.data.perspectiveQueryLinks;
-
-          for (let i = 0; i < channelLinks.length; i++) {
-            //Check that the channel is not in the store
-            if (
-              Object.values(community.neighbourhood.linkedNeighbourhoods).find(
-                (neighbourhoodUrl) =>
-                  neighbourhoodUrl === channelLinks[i].data!.target
-              ) == undefined
-            ) {
-              console.log(
-                "Found channel link",
-                channelLinks[i],
-                "Adding to channel"
-              );
-              //Call ad4m and try to join the sharedperspective found at link target
-              const channel = await joinChannelFromSharedLink(
-                channelLinks[i].data!.target!,
-                community.neighbourhood.perspective.uuid
-              );
-              console.log(
-                "trying to join channel",
-                channel,
-                community.neighbourhood.perspective.uuid
-              );
-              //Add the channel to the store
-              dataStore.addChannel({
-                communityId: community.neighbourhood.perspective.uuid,
-                channel: channel,
-              });
-            }
-          }
-          isCallbackRunning = false;
-        } catch (error) {
-          isCallbackRunning = false;
-          throw new Error(error);
-        }
+    for (let i = 0; i < channelLinks.length; i++) {
+      //Check that the channel is not in the store
+      if (
+        Object.values(community.neighbourhood.linkedNeighbourhoods).find(
+          (neighbourhoodUrl) =>
+            neighbourhoodUrl === channelLinks[i].data!.target
+        ) == undefined
+      ) {
+        console.log("Found channel link", channelLinks[i], "Adding to channel");
+        //Call ad4m and try to join the sharedperspective found at link target
+        const channel = await joinChannelFromSharedLink(
+          channelLinks[i].data!.target!,
+          community.neighbourhood.perspective.uuid
+        );
+        console.log(
+          "trying to join channel",
+          channel,
+          community.neighbourhood.perspective.uuid
+        );
+        //Add the channel to the store
+        dataStore.addChannel({
+          communityId: community.neighbourhood.perspective.uuid,
+          channel: channel,
+        });
       }
-    });
-    return channelLinksWorker;
+    }
   } catch (e) {
     throw new Error(e);
   }

--- a/src/store/data/getters/index.ts
+++ b/src/store/data/getters/index.ts
@@ -59,6 +59,19 @@ export default {
       };
     },
 
+  getNeighbourhoodByUrl:
+    (state: DataState) =>
+    (url: string): NeighbourhoodState | null => {
+      const neighbourhood = Object.values(state.neighbourhoods)
+        .filter((community) => community.perspective.sharedUrl === url)
+        .pop();
+      if (neighbourhood == undefined) {
+        return null;
+      } else {
+        return neighbourhood;
+      }
+    },
+
   getCommunityState:
     (state: DataState) =>
     (id: string): LocalCommunityState => {


### PR DESCRIPTION
# Plan

- Remove polling for channels, group expressions & members and replace with calls on channel route changes
- Add logic to check signals for new group expressions & members and update state accordingly

# Blockers

- Since holochain calls are not going to the DHT when joining if we dont poll for channels we never get any channels when joining a neighbourhood
- We should not create another channel for the home channel but instead use the source neighbourhood so a user always has a channel to use when joining a community